### PR TITLE
Refactor PDF.js import to use dynamic import.

### DIFF
--- a/src/pdf-to-png.ts
+++ b/src/pdf-to-png.ts
@@ -3,13 +3,13 @@
  */
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs'
 
 const PDFJS_DIR = join(dirname(require.resolve('pdfjs-dist')), '..')
 
 export async function pdfToPng(
   pdf: string | Buffer
 ): Promise<Buffer[]> {
+  const { getDocument } = await import('pdfjs-dist/legacy/build/pdf.mjs')
 
   // Load PDF
   const data = new Uint8Array(Buffer.isBuffer(pdf) ? pdf : readFileSync(pdf))


### PR DESCRIPTION
Switched from static to dynamic import for PDF.js to improve compatibility and possibly reduce initial load time. This change ensures the module is imported only when needed during runtime.